### PR TITLE
embedded: allow custom API URL

### DIFF
--- a/src/embedded/embedded.ts
+++ b/src/embedded/embedded.ts
@@ -8,9 +8,12 @@ const addSaveOptionHandler = () => {
   return
 }
 
+// Set `window.clickInTextApiUrl` before `require()`ing `embedded.js` to point
+// at a custom server
+const apiUrl : string | undefined = (window as any).clickInTextApiUrl;
 
 const asyncGetTranslation = (word, callback) => {
-  Core.callAPI(word, Core.parseAPIResponse, callback)
+  Core.callAPI(word, Core.parseAPIResponse, callback, {apiUrl})
 }
 
 const addTATAndCopyPasteListener = function (callback) {

--- a/src/lib/transover_core.ts
+++ b/src/lib/transover_core.ts
@@ -102,6 +102,10 @@ const Core = {
   ): void {
     const apiUrl = options?.apiUrl ?? 'https://itwewina.altlab.app/click-in-text/?q=';
 
+    if (!word) {
+      return;
+    }
+
     const ajaxRequestSettings = {
       url: apiUrl + encodeURIComponent(word),
       dataType: 'json',

--- a/src/lib/transover_core.ts
+++ b/src/lib/transover_core.ts
@@ -94,10 +94,16 @@ type ResponseParser = (data: { "results": SerializedSearchResult[] }, word: stri
 const Core = {
 
   // where translate api happens
-  callAPI(word: string, responseParser: ResponseParser, sendParsedResponse: SendParsedResponse): void {
+  callAPI(
+      word: string,
+      responseParser: ResponseParser,
+      sendParsedResponse: SendParsedResponse,
+      options?: {apiUrl: string}
+  ): void {
+    const apiUrl = options?.apiUrl ?? 'https://itwewina.altlab.app/click-in-text/?q=';
 
-    const options = {
-      url: 'https://itwewina.altlab.app/click-in-text/?q=' + word,
+    const ajaxRequestSettings = {
+      url: apiUrl + encodeURIComponent(word),
       dataType: 'json',
       success: function on_success(data) {
         const parsedResponse = responseParser(data, word)
@@ -107,7 +113,7 @@ const Core = {
         console.error({e: e, xhr: xhr})
       }
     }
-    $.ajax(options)
+    $.ajax(ajaxRequestSettings)
   },
 
   parseAPIResponse(data: { "results": SerializedSearchResult[] }, word: string): ParsedResponse {


### PR DESCRIPTION
This PR adds support for a `window.clickInTextApiUrl` variable which sets the URL for the API. This will allow for setting the API URL to localhost for testing.