### PR TITLE
Declare only the types we actually use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@altlab/types": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@altlab/types/-/types-1.1.1.tgz",
-      "integrity": "sha512-BtUaU6BxIeBLH84g25Sssfs894PNE2BpZ68aU6IpGcPqOpnB7HFC6jXUa6M6EssT49Wm+lP1VQYpBiTaFftuoQ==",
-      "dev": true
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint-fix": "eslint --fix . --ext .ts,.js"
   },
   "devDependencies": {
-    "@altlab/types": "^1.1.1",
     "@types/chrome": "0.0.127",
     "@types/jquery": "^3.5.5",
     "@types/node": "^14.14.11",

--- a/src/lib/transover_core.ts
+++ b/src/lib/transover_core.ts
@@ -1,6 +1,5 @@
 import {TransOver} from './transover_utils'
 import XRegExp from 'xregexp/src'
-import {SerializedSearchResult} from '@altlab/types'
 import {options} from "./options";
 /// <reference path="html_loader.d.ts"/>
 import popup from './popup.html'
@@ -11,6 +10,7 @@ import Node = JQuery.Node;
 /// <reference path="raw_loader.d.ts"/>
 import popupScript from 'raw-loader!ts-loader!./popup.raw'
 import tatPopupScript from 'raw-loader!ts-loader!./tat_popup.raw'
+import {SerializedSearchResult} from "./types";
 
 
 const popupTemplate = buildTemplateFromString(popup)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,14 @@
+// These are the things returned by the intelligent dictionary click-in-text API
+// that are actually used by this package.
+
+export interface SerializedDefinition {
+    text: string;
+    source_ids: string[];
+}
+export interface SerializedWordform {
+    text: string;
+    definitions: SerializedDefinition[];
+}
+export interface SerializedSearchResult {
+    lemma_wordform: SerializedWordform;
+}


### PR DESCRIPTION
The `@altlab/types` version of `SerializedSearchResult` exposes a bunch
of internal fields that we don’t want to support and in fact want to
rename, or get rid of. This minimal set will be much easier to maintain.